### PR TITLE
Remove double incrementing of the counter in ThreadRunnableInterfaceRunner

### DIFF
--- a/Chapter09/Threading/src/main/java/com/kenfogel/threading/ThreadRunnableInterfaceRunner.java
+++ b/Chapter09/Threading/src/main/java/com/kenfogel/threading/ThreadRunnableInterfaceRunner.java
@@ -16,7 +16,7 @@ public class ThreadRunnableInterfaceRunner {
              * constructor a reference to a Runnable thread and the thread name.
              * Now we can call start().
              */
-            new Thread(new ThreadRunnableInterface(), "" + ++i).start();
+            new Thread(new ThreadRunnableInterface(), "" + i).start();
         }
     }
 


### PR DESCRIPTION
The loop counter is incremented twice: first, in the loop header, then again in the loop body. Wrong number of threads is instantiated as a result.